### PR TITLE
fix: reduce allocations in streaming example

### DIFF
--- a/tutorial/io/alpha_reader2.go
+++ b/tutorial/io/alpha_reader2.go
@@ -25,19 +25,21 @@ func alpha(r byte) byte {
 }
 
 func (a *alphaReader) Read(p []byte) (int, error) {
-	n, err := a.reader.Read(p)
+	n, err := r.reader.Read(p)
 	if err != nil {
 		return n, err
 	}
-	buf := make([]byte, n)
+	j := 0
 	for i := 0; i < n; i++ {
 		if char := alpha(p[i]); char != 0 {
-			buf[i] = char
+			p[j] = char
+			j += 1
 		}
 	}
-
-	copy(p, buf)
-	return n, nil
+	if j == 0 {
+		return 0, io.EOF
+	}
+	return j, nil
 }
 
 func main() {

--- a/tutorial/io/alpha_reader2.go
+++ b/tutorial/io/alpha_reader2.go
@@ -25,7 +25,7 @@ func alpha(r byte) byte {
 }
 
 func (a *alphaReader) Read(p []byte) (int, error) {
-	n, err := r.reader.Read(p)
+	n, err := a.reader.Read(p)
 	if err != nil {
 		return n, err
 	}


### PR DESCRIPTION
The modified example in this PR will filter from a stream while reusing the original buffer. This avoids the overhead from allocation of another buffer on every call to Read.