### PR TITLE
Fixes for golang.fyi broken deploy 

### DIFF
--- a/golangfyi/app.yaml
+++ b/golangfyi/app.yaml
@@ -2,4 +2,4 @@ runtime: go111
 
 handlers:
 - url: /.*
-  script: _go_app
+  script: auto

--- a/golangfyi/app.yaml
+++ b/golangfyi/app.yaml
@@ -1,5 +1,4 @@
-runtime: go
-api_version: go1
+runtime: go111
 
 handlers:
 - url: /.*


### PR DESCRIPTION
According to https://cloud.google.com/appengine/docs/standard/go111/go-differences